### PR TITLE
Image download links

### DIFF
--- a/meshchat
+++ b/meshchat
@@ -538,8 +538,22 @@ function file_download()
     release_lock()
 
     print("Content-MD5: " .. md5 .. "\r")
-    print("Content-Disposition: attachment; filename=\"" .. file .. "\";\r")
-    print("Content-type: application/octet-stream\r")
+
+    local ext = string.match(file, "%.(%a+)$")
+    local content_type
+
+    if ext == "jpg" or ext == "jpeg" then
+        content_type = "image/jpeg"
+    elseif ext == "png" then
+        content_type = "image/png"
+    elseif ext == "gif" then
+        content_type = "image/gif"
+    else
+        print("Content-Disposition: attachment; filename=\"" .. file .. "\";\r")
+        content_type = "application/octet-stream"
+    end
+
+    print("Content-Type: " .. content_type .. "\r")
     print("\r")
 
     if f then

--- a/www/files.js
+++ b/www/files.js
@@ -110,7 +110,7 @@ function load_files() {
                     port = ':8080'
                 }
             }
-            html += '<td><a href="/cgi-bin/meshchat?action=file_download&file=' + encodeURIComponent(data.files[i].file) + '" target="_blank">' + data.files[i].file +
+            html += '<td><a href="/cgi-bin/meshchat?action=file_download&file=' + encodeURIComponent(data.files[i].file) + '" target="_blank">' + data.files[i].file + '</a></td>';
             html += '<td>' + numeral(data.files[i].size).format('0.0 b') + '</td>';
             html += '<td class="col_node">' + data.files[i].node + '</td>';
             html += '<td class="col_time">' + format_date(date) + '</td>';

--- a/www/files.js
+++ b/www/files.js
@@ -110,7 +110,7 @@ function load_files() {
                     port = ':8080'
                 }
             }
-            html += '<td><a href="http://' + aredn_domain(data.files[i].node) + port + '/cgi-bin/meshchat?action=file_download&file=' + encodeURIComponent(data.files[i].file) + '">' + data.files[i].file + '</a></td>';
+            html += '<td><a href="/cgi-bin/meshchat?action=file_download&file=' + encodeURIComponent(data.files[i].file) + '" target="_blank">' + data.files[i].file +
             html += '<td>' + numeral(data.files[i].size).format('0.0 b') + '</td>';
             html += '<td class="col_node">' + data.files[i].node + '</td>';
             html += '<td class="col_time">' + format_date(date) + '</td>';


### PR DESCRIPTION
I've made a few changes to my meshchat:
- Octet-stream for attachments, inline and content-type for images.
- Relative download link for attachments.
- Open in new tab (affects images, attachments continue to work normally).

(I access my AREDN node in an odd way sometimes and using an absolute link instead of a relative link makes assumption about DNS resolution when I'm using the IP.)