### PR TITLE
Update zone name discovery to ignore icon metadata

### DIFF
--- a/meshchatlib.lua
+++ b/meshchatlib.lua
@@ -89,7 +89,10 @@ function zone_name()
     if nixio.fs.access(servfile) then
         for line in io.lines(servfile)
         do
-            local zone = line:match("^(.*)|.*|.*|.*|.*|meshchat$")
+            -- this will match the new service names with the icon metadata
+            -- in this case we are using a space or a pipe to terminate
+            -- the service name
+            local zone = line:match("^(.-)[%s%|].*|meshchat$")
             if zone then
                 return zone
             end


### PR DESCRIPTION
This correctly allows MeshChat to discover its zone name when the new service definition is being used. Otherwise MeshChat would discover its zone name with an appended ` [chat]` to the zone name. 